### PR TITLE
Añadir enlace a la Pauta de ofertas Laborales

### DIFF
--- a/Reglamento Oficial.md
+++ b/Reglamento Oficial.md
@@ -84,7 +84,7 @@
 
 **Queda estrictamente prohibido**:   
 
-**5.1** Todas las ofertas laborales que no sigan la Pauta Oficial de la Comunidad.
+**5.1** Todas las ofertas laborales que no sigan la [Pauta Oficial de la Comunidad](Pauta%20Laboral.md).
 
 **5.2** No incluir los campos mencionados en la pauta.
 


### PR DESCRIPTION
Creo que es conveniente darle al usuario que entra a leer las reglas la posibilidad de dar click en el enlace a la pauta de las ofertas laborales, en vez de obligarlos a tener que hacer click" en "atrás" y entrar al archivo de las pautas.